### PR TITLE
fix: 修复flink k8s operator部署任务时偶尔会在部署完成后重新部署一遍的问题 --bug=142963010

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,21 @@
 ################################################################################
 # Build
 ARG JAVA_VERSION=11
-FROM maven:3.8.8-eclipse-temurin-${JAVA_VERSION} AS build
+FROM mirrors.tencent.com/tjdk/tencentkona${JAVA_VERSION}-ts4 AS build
 ARG SKIP_TESTS=true
 ARG HTTP_CLIENT=okhttp
+ARG MAVEN_HOME=/opt/apache-maven-3.8.8
+
+WORKDIR /opt
+RUN set -ex \
+    && yum -y update \
+    && yum install -y wget \
+    && wget -O maven.tar.gz "https://mirrors.tencent.com/apache/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz" \
+    && mkdir -p $MAVEN_HOME \
+    && tar -xvzf maven.tar.gz -C /opt/apache-maven-3.8.8 --strip-components 1 \
+    && ls -alh \
+    && rm maven.tar.gz
+ENV PATH=${MAVEN_HOME}/bin:$PATH
 
 WORKDIR /app
 
@@ -36,7 +48,7 @@ RUN cd /app/tools/license; mkdir jars; cd jars; \
     cd ../ && ./collect_license_files.sh ./jars ./licenses-output
 
 # stage
-FROM eclipse-temurin:${JAVA_VERSION}-jre-jammy
+FROM mirrors.tencent.com/tjdk/tencentkona${JAVA_VERSION}-ts4
 ENV FLINK_HOME=/opt/flink
 ENV FLINK_PLUGINS_DIR=$FLINK_HOME/plugins
 ENV OPERATOR_VERSION=1.11.1
@@ -69,15 +81,14 @@ COPY --chown=flink:flink docker-entrypoint.sh /
 ARG SKIP_OS_UPDATE=true
 
 # Updating Debian
-RUN if [ "$SKIP_OS_UPDATE" = "false" ]; then apt-get update; fi
-RUN if [ "$SKIP_OS_UPDATE" = "false" ]; then apt-get upgrade -y; fi
+RUN if [ "$SKIP_OS_UPDATE" = "false" ]; then yum update -y; fi
+RUN if [ "$SKIP_OS_UPDATE" = "false" ]; then yum upgrade -y; fi
 
 ARG DISABLE_JEMALLOC=false
 # Install jemalloc
 RUN if [ "$DISABLE_JEMALLOC" = "false" ]; then \
-  apt-get update; \
-  apt-get -y install libjemalloc-dev lrzsz; \
-  rm -rf /var/lib/apt/lists/*; \
+  yum update; \
+  yum -y install jemalloc lrzsz; \
   fi
 
 USER flink

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -120,6 +120,11 @@ public abstract class AbstractJobReconciler<
 
         JobState currentJobState = lastReconciledSpec.getJob().getState();
         JobState desiredJobState = currentDeploySpec.getJob().getState();
+        LOG.info(
+                "currentJobState: {}, desiredJobState: {}, diffType: {}",
+                currentJobState,
+                desiredJobState,
+                diffType);
 
         if (diffType == DiffType.SAVEPOINT_REDEPLOY) {
             redeployWithSavepoint(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -98,13 +98,21 @@ public class ApplicationReconciler
         }
 
         var jmDeployStatus = status.getJobManagerDeploymentStatus();
+        UpgradeMode upgradeMode =
+                status.getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getUpgradeMode();
+        boolean isJmPodNeverStarted = FlinkUtils.jmPodNeverStarted(ctx.getJosdkContext());
+
+        LOG.info(
+                "jmDeployStatus: {}, upgradeMode: {}, isJmPodNeverStarted: {}",
+                jmDeployStatus,
+                upgradeMode,
+                isJmPodNeverStarted);
         if (jmDeployStatus != JobManagerDeploymentStatus.MISSING
-                && status.getReconciliationStatus()
-                                .deserializeLastReconciledSpec()
-                                .getJob()
-                                .getUpgradeMode()
-                        != UpgradeMode.LAST_STATE
-                && FlinkUtils.jmPodNeverStarted(ctx.getJosdkContext())) {
+                && upgradeMode != UpgradeMode.LAST_STATE
+                && isJmPodNeverStarted) {
             deleteJmThatNeverStarted(flinkService, deployment, deployConfig);
             return getJobUpgrade(ctx, deployConfig);
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -338,6 +338,10 @@ public class NativeFlinkService extends AbstractFlinkService {
                                 // Ignore all errors here as this is an optional step
                                 return null;
                             }
+                            var podName = JobManagerInfoCache.getPodName(clusterId);
+                            if (podName == null) {
+                                return null;
+                            }
                             return kubernetesClient
                                     .pods()
                                     .inNamespace(namespace)

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -54,6 +54,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -426,9 +427,15 @@ public class FlinkUtils {
             Deployment deployment = depOpt.get();
             for (DeploymentCondition condition : deployment.getStatus().getConditions()) {
                 if (condition.getType().equals("Available")) {
-                    var createTs = deployment.getMetadata().getCreationTimestamp();
+                    var createTs = Instant.parse(deployment.getMetadata().getCreationTimestamp());
+                    var lastTransitionTime = Instant.parse(condition.getLastTransitionTime());
+                    LOG.info("Job deployment status condition: {}", condition);
+                    LOG.info(
+                            "Job deployment createTs: {}, status lastTransitionTime: {}",
+                            createTs,
+                            lastTransitionTime);
                     if ("False".equals(condition.getStatus())
-                            && createTs.equals(condition.getLastTransitionTime())) {
+                            && lastTransitionTime.minusSeconds(10).isBefore(createTs)) {
                         return true;
                     }
                 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/JobManagerInfoCache.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/JobManagerInfoCache.java
@@ -115,6 +115,7 @@ public final class JobManagerInfoCache {
                                         case DELETED:
                                             LOG.info("DELETE jobmanager info cache: {}", clusterId);
                                             cache.invalidate(clusterId);
+                                            break;
                                         default:
                                             break;
                                     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request adds a new feature to periodically create and maintain savepoints through the `FlinkDeployment` custom resource.)*


## Brief change log

*(for example:)*
  - *Periodic savepoint trigger is introduced to the custom resource*
  - *The operator checks on reconciliation whether the required time has passed*
  - *The JobManager's dispose savepoint API is used to clean up obsolete savepoints*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / no)
  - Core observer or reconciler logic that is regularly executed: (yes / no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
